### PR TITLE
Fix preview command

### DIFF
--- a/.github/workflows/wix-cli.yml
+++ b/.github/workflows/wix-cli.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           node-version: 18
       - run: npm install -g @wix/cli
-      - run: wix login --api-key ${{ secrets.WIX_CLI_TOKEN }}
-      - run: wix site preview
+      - run: wix login --api-key ${{ secrets.WIX_CLI_API_KEY }}
+      - run: wix preview


### PR DESCRIPTION
## Summary
- fix the GitHub Actions step to use the correct preview command
- use `WIX_CLI_API_KEY` secret as documented

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684f79cf0e808328b16c5dd1dbdbf6ec