### PR TITLE
Handle CI postinstall for wix CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "react": "16.14.0"
   },
   "scripts": {
-    "postinstall": "wix sync-types",
+    "postinstall": "node scripts/postinstall.js",
     "dev": "wix dev",
     "lint": "eslint ."
   }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require('child_process');
+
+const isCI = process.env.CI;
+const isTTY = process.stdout.isTTY;
+
+if (!isCI && isTTY) {
+  const result = spawnSync('npx', ['wix', 'sync-types'], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+} else {
+  console.log('Skipping `wix sync-types` due to non-interactive environment');
+}


### PR DESCRIPTION
## Summary
- skip `wix sync-types` when `npm install` runs in CI
- add small `postinstall.js` helper script

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f8571e9408328a6d40b22131ab470