### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 echo "husky - DEPRECATED
 
 Please remove the following two lines from $0:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -80,10 +80,10 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
   HUSKY_MAJOR=$(node -e "console.log(require('./node_modules/husky/package.json').version.split('.')[0])")
   if [[ $HUSKY_MAJOR -ge 9 ]]; then
     npx --yes husky hook add pre-commit "npx lint-staged"
-    npx --yes husky hook add commit-msg 'npx --no -- commitlint --edit "$1"'
+    npx --yes husky hook add commit-msg "npx --no -- commitlint --edit \"$1\""
   else
     npx --yes husky add .husky/pre-commit "npx lint-staged"
-    npx --yes husky add .husky/commit-msg 'npx --no -- commitlint --edit "$1"'
+    npx --yes husky add .husky/commit-msg "npx --no -- commitlint --edit \"$1\""
   fi
 
   # ensure hooks are installed after every install


### PR DESCRIPTION
## Summary
- add missing shebangs for husky helper scripts
- quote commitlint commands correctly in `bootstrap.sh`

## Testing
- `npm run lint`
- `shellcheck bootstrap.sh .husky/_/husky.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f93d78c048328b9b0d3609e38f9c0