### PR TITLE
Improve CI configs and Node targeting

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Wix CLI
         run: npm install -g @wix/cli

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .idea/
 .wix/
 jsconfig.json
+.eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,17 @@
 # MLS Website Repository Guidelines
 
 ## Environment Setup
+
 - Use Node.js 22 via `nvm use` (see `.nvmrc`).
 - Install dependencies with `npm install`.
 - Install Wix CLI globally with `npm install -g @wix/cli`.
 
 ## Development Workflow
+
 - Run `npm run dev` to open the local Wix Editor.
 - Run `npm run lint` before committing.
 
 ## CI/CD
-- The GitHub Actions workflow `.github/workflows/wix-cli.yml` builds a preview of the site using the Wix CLI.
-- Configure the `WIX_CLI_API_KEY` secret in GitHub for authentication.
 
+- The GitHub Actions workflow `.github/workflows/wix-cli.yml` builds a preview of the site using the Wix CLI.
+- Configure the `WIX_CLI_TOKEN` secret in GitHub for authentication.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Learn more about [working with the Wix CLI](https://support.wix.com/en/article/v
 
 ## Automated preview workflow
 
-This repo includes a GitHub Actions workflow that installs the Wix CLI and builds a preview of your site whenever code is pushed to the `main` branch. To enable it, add a `WIX_CLI_API_KEY` secret in your repository settings so the workflow can authenticate with your Wix site.
+This repo includes a GitHub Actions workflow that installs the Wix CLI and builds a preview of your site whenever code is pushed to the `main` branch. To enable it, add a `WIX_CLI_TOKEN` secret in your repository settings so the workflow can authenticate with your Wix site.
 
 The preview URL is posted on each pull request. A follow-up workflow checks Lighthouse performance and accessibility scores and optimizes images. Publishing to production requires approving the `Publish` workflow once these checks pass.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "husky": "^9.1.7",
         "lint-staged": "^15.5.2",
         "prettier": "^3.2.5"
+      },
+      "engines": {
+        "node": "22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "lint-staged": "^15.5.2",
     "prettier": "^3.2.5"
   },
+  "engines": {
+    "node": "22"
+  },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "dev": "wix dev",
-    "lint": "eslint . --ext .js,.ts --max-warnings=0",
+    "lint": "eslint . --ext .js,.ts --max-warnings=0 --cache",
     "format": "prettier --write .",
     "prettier:check": "prettier --check .",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- specify Node 22 via `engines` in `package.json`
- enable ESLint caching for faster runs
- use `npm ci` in the preview workflow for reproducible installs
- align workflow secret names with repo docs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f9612e12083289a337e870e91672c