### PR TITLE
Update lighthouse script to preconnect fonts earlier

### DIFF
--- a/src/public/lighthouse.js
+++ b/src/public/lighthouse.js
@@ -1,13 +1,13 @@
 // /public/lighthouse.js
 // Add 'loading="lazy"' to all images except the first hero/LCP image
-window.addEventListener("load", () => {
-  // Preconnect to Google Fonts to improve FCP
-  const fonts = document.createElement("link")
-  fonts.rel = "preconnect"
-  fonts.href = "https://fonts.gstatic.com"
-  fonts.crossOrigin = "anonymous"
-  document.head.appendChild(fonts)
+// Preconnect to Google Fonts early to improve FCP
+const fonts = document.createElement("link")
+fonts.rel = "preconnect"
+fonts.href = "https://fonts.gstatic.com"
+fonts.crossOrigin = "anonymous"
+document.head.appendChild(fonts)
 
+window.addEventListener("load", () => {
   const images = document.querySelectorAll("img:not([loading])")
   images.forEach((img, idx) => {
     // Keep the very first hero image eager for better LCP


### PR DESCRIPTION
## Summary
- tweak `lighthouse.js` so the fonts preconnect tag is inserted before the window `load` event

## Testing
- `npm run lint`
- `npx lighthouse https://www.cryptolistings.ai --quiet --only-categories=performance --output=json --output-path=./lighthouse.json` *(fails: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_684f9a40d2a08328a6ad9a99d26aa4c1